### PR TITLE
Fix docker-compose invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ download_datasets:
 
 serve:
 	lsof -t -i :5002 | xargs kill -9 # Kill orphaned rails server
-	docker-compose up --build -d --remove-orphans
+	docker compose up --build -d --remove-orphans
 	DEBUG=true foreman start -f Procfile.dev -c "worker=2,web=1,scheduler=1"
 
 test_small:


### PR DESCRIPTION
- Update dataset path in Makefile and improve error handling in MLflow client.
- Improve error message for missing course stage in AutofixRequest model.
- Update dataset validation command and improve logging in dataset validator.
- Update Makefile to use 'docker compose' instead of 'docker-compose' command.
