### PR TITLE
Use 4o-mini, stage 2

### DIFF
--- a/app/prompts/edit_wrong_submission_v1_prompt.rb
+++ b/app/prompts/edit_wrong_submission_v1_prompt.rb
@@ -1,6 +1,6 @@
 class EditWrongSubmissionV1Prompt < BasePrompt
-  model "gpt-4o"
-  provider :azure, deployment_name: "gpt-4o"
+  model "gpt-4o-mini"
+  provider :azure, deployment_name: "gpt-4o-mini"
 
   # model "gpt-3.5-turbo-1106" # Temporary, until we do optimized edits
 

--- a/app/prompts/generate_hint_v1_prompt.rb
+++ b/app/prompts/generate_hint_v1_prompt.rb
@@ -1,6 +1,6 @@
 class GenerateHintV1Prompt < BasePrompt
-  model "gpt-4o"
-  provider :azure, deployment_name: "gpt-4o"
+  model "gpt-4o-mini"
+  provider :azure, deployment_name: "gpt-4o-mini"
 
   # Context: course, stage, language, changed_files, test_runner_output
   def call


### PR DESCRIPTION
- Update model and provider names to "gpt-4o" in prompts and fix header formatting.
- Update model and provider names to "gpt-4o-mini" in prompts.
